### PR TITLE
[Legal] Add NOTICE file (Apache-2.0 Section 4(d))

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+RUNE Airgapped
+Copyright 2025-2026 The Rune Authors
+
+This product is licensed under the Apache License, Version 2.0.


### PR DESCRIPTION
## Summary

- Adds NOTICE file with project attribution as required by Apache-2.0 Section 4(d)

Closes #31
Part of lpasquali/rune#133

## DoD Level

- [ ] **Level 1** — Full Validation
- [ ] **Level 2** — Test Infrastructure
- [x] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence

- NOTICE file exists at repo root
- Contains Copyright 2025-2026 The Rune Authors

## Audit Checks

No triggers fired. Legal metadata file only.

## Breaking Changes

None.