### PR TITLE
feat: add TLS certificate generation script for internal services

### DIFF
--- a/scripts/generate-certs.sh
+++ b/scripts/generate-certs.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 RUNE Contributors
+#
+# Generates self-signed TLS certificates for internal RUNE services (Zot registry, API, UI).
+
+set -euo pipefail
+
+OUT_DIR="${1:-certs}"
+mkdir -p "${OUT_DIR}"
+cd "${OUT_DIR}"
+
+echo "Generating Root CA..."
+openssl req -x509 -nodes -newkey rsa:4096 -days 3650 \
+  -keyout ca.key -out ca.crt -subj "/CN=RUNE Airgapped Root CA"
+
+generate_cert() {
+  local service=$1
+  local cn=$2
+  local sans=$3
+  echo "Generating certificate for ${service}..."
+  
+  openssl req -new -nodes -newkey rsa:2048 \
+    -keyout "${service}.key" -out "${service}.csr" -subj "/CN=${cn}"
+    
+  cat > "${service}-extfile.cnf" <<EOF
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = ${sans}
+EOF
+
+  openssl x509 -req -in "${service}.csr" -CA ca.crt -CAkey ca.key -CAcreateserial \
+    -out "${service}.crt" -days 825 -extfile "${service}-extfile.cnf"
+    
+  rm -f "${service}.csr" "${service}-extfile.cnf"
+}
+
+# Zot Registry
+generate_cert "zot" "zot.rune-registry.svc.cluster.local" "DNS:zot.rune-registry.svc.cluster.local,DNS:zot.rune-registry.svc,DNS:zot,DNS:localhost"
+
+# RUNE API
+generate_cert "rune-api" "rune-api.rune.svc.cluster.local" "DNS:rune-api.rune.svc.cluster.local,DNS:rune-api.rune.svc,DNS:rune-api,DNS:localhost"
+
+# RUNE UI
+generate_cert "rune-ui" "rune-ui.rune.svc.cluster.local" "DNS:rune-ui.rune.svc.cluster.local,DNS:rune-ui.rune.svc,DNS:rune-ui,DNS:localhost"
+
+echo "Certificates generated successfully in ${OUT_DIR}/"


### PR DESCRIPTION
## Summary
TLS certificate generation for internal services

Adds a script to generate self-signed TLS certificates (with appropriate Subject Alternative Names) for Zot, RUNE API, and RUNE UI to support secure airgapped deployments.

Closes #16

## DoD Level
- [ ] **Level 1 — Full Validation**
- [x] **Level 2 — Test Infrastructure**
- [ ] **Level 3 — Documentation**

## Acceptance Criteria Evidence
- [x] Script `generate-certs.sh` created and executable.
- [x] Script successfully passes `shellcheck`.

## Audit Checks
| Check | Result |
|---|---|
| `cyber check:api` | PASS |

## Breaking Changes
None.

## Test plan
- [x] `shellcheck scripts/*.sh` passes.
