### PR TITLE
ci: add permissions block to project-sync workflow

### DIFF
--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -5,7 +5,10 @@ on:
   issues:
     types: [opened, closed, reopened, labeled, unlabeled, assigned, unassigned]
   pull_request:
-    types: [opened, closed, reopened, ready_for_review, converted_to_draft, labeled, unlabeled, synchronized]
+    types: [opened, closed, reopened, ready_for_review, converted_to_draft, labeled, unlabeled, synchronize]
+
+permissions:
+  contents: read
 
 jobs:
   sync:


### PR DESCRIPTION
## Summary
- Add minimal `permissions: contents: read` to project-sync.yml (CodeQL workflow-permissions)
- Fix `synchronized` → `synchronize` (correct GitHub event type)

Closes #0

## DoD Level
- [ ] **Level 1** — Full Validation
- [x] **Level 2** — Test Infrastructure
- [ ] **Level 3** — Documentation Validation

## Acceptance Criteria Evidence
- [x] project-sync.yml now has explicit permissions block
- [x] Event type typo corrected

## Audit Checks
| Check | Result |
| --- | --- |
| `cyber check:supply-chain` | PASS |

## Breaking Changes
None.

## Test plan
- [x] YAML syntax valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)