### PR TITLE
chore(ci): adopt rune-ci@eae1383 merge gate policy

### DIFF
--- a/.github/workflows/bundle-ci.yml
+++ b/.github/workflows/bundle-ci.yml
@@ -307,28 +307,12 @@ jobs:
           echo "--- All manifest validations passed ---"
 
   # ---------------------------------------------------------------------------
-  # Merge gate: aggregates all job results
+  # Merge gate: shared policy (rune-ci)
   # ---------------------------------------------------------------------------
   merge-gate:
     name: "Merge Gate"
     if: always()
     needs: [validate-scripts, unit-tests, build-bundle, checksum-verify]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check job results
-        run: |
-          echo "=== Merge Gate ==="
-          echo "validate-scripts: ${{ needs.validate-scripts.result }}"
-          echo "unit-tests:       ${{ needs.unit-tests.result }}"
-          echo "build-bundle:     ${{ needs.build-bundle.result }}"
-          echo "checksum-verify:  ${{ needs.checksum-verify.result }}"
-
-          if [[ "${{ needs.validate-scripts.result }}" != "success" ]] || \
-             [[ "${{ needs.unit-tests.result }}" != "success" ]] || \
-             [[ "${{ needs.build-bundle.result }}" != "success" ]] || \
-             [[ "${{ needs.checksum-verify.result }}" != "success" ]]; then
-            echo "FAIL: One or more jobs did not succeed"
-            exit 1
-          fi
-
-          echo "PASS: All jobs succeeded"
+    uses: lpasquali/rune-ci/.github/workflows/merge-gate-from-needs.yml@eae13830420fe3b9d558edb081c01c90bdc01d03
+    with:
+      needs-json: ${{ toJson(needs) }}

--- a/.github/workflows/bundle-ci.yml
+++ b/.github/workflows/bundle-ci.yml
@@ -313,6 +313,6 @@ jobs:
     name: "Merge Gate"
     if: always()
     needs: [validate-scripts, unit-tests, build-bundle, checksum-verify]
-    uses: lpasquali/rune-ci/.github/workflows/merge-gate-from-needs.yml@eae13830420fe3b9d558edb081c01c90bdc01d03
+    uses: lpasquali/rune-ci/.github/workflows/merge-gate-from-needs.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b
     with:
       needs-json: ${{ toJson(needs) }}

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -16,15 +16,15 @@ permissions:
 
 jobs:
   security:
-    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
+    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
 
   shell:
-    uses: lpasquali/rune-ci/.github/workflows/shell-quality.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
+    uses: lpasquali/rune-ci/.github/workflows/shell-quality.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
     with:
       script-dirs: "scripts"
 
   validate:
-    uses: lpasquali/rune-ci/.github/workflows/generic-validate.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
+    uses: lpasquali/rune-ci/.github/workflows/generic-validate.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
     with:
       validate-yaml: "scripts/validate_yaml.py"
       validate-vex: "scripts/validate_vex.py"
@@ -32,6 +32,6 @@ jobs:
   compliance:
     needs: [security, shell, validate]
     if: always()
-    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
+    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
     with:
       needs-json: ${{ toJson(needs) }}

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -16,15 +16,15 @@ permissions:
 
 jobs:
   security:
-    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@b242495fb92b046879c9e0ecb8e88a0e89e0e7d5 # main
+    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
 
   shell:
-    uses: lpasquali/rune-ci/.github/workflows/shell-quality.yml@b242495fb92b046879c9e0ecb8e88a0e89e0e7d5 # main
+    uses: lpasquali/rune-ci/.github/workflows/shell-quality.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
     with:
       script-dirs: "scripts"
 
   validate:
-    uses: lpasquali/rune-ci/.github/workflows/generic-validate.yml@b242495fb92b046879c9e0ecb8e88a0e89e0e7d5 # main
+    uses: lpasquali/rune-ci/.github/workflows/generic-validate.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
     with:
       validate-yaml: "scripts/validate_yaml.py"
       validate-vex: "scripts/validate_vex.py"
@@ -32,6 +32,6 @@ jobs:
   compliance:
     needs: [security, shell, validate]
     if: always()
-    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@b242495fb92b046879c9e0ecb8e88a0e89e0e7d5 # main
+    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@eae13830420fe3b9d558edb081c01c90bdc01d03 # main
     with:
       needs-json: ${{ toJson(needs) }}


### PR DESCRIPTION
## Summary

Pins `lpasquali/rune-ci` reusable workflows to `eae13830420fe3b9d558edb081c01c90bdc01d03` and removes the redundant top-level `merge-gate` job so the **Merge Gate** enforced inside `pr-compliance` is authoritative (SoD / epic https://github.com/lpasquali/rune-ci/issues/25).

Fixes #74

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [x] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [ ] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 2 Checklist

- [x] Full test suite passes (via Quality Gates on this PR)
- [x] Coverage not degraded (at or above floor)
- [x] No unintended CI side effects (workflow-only change)

## Audit Checks

No triggers fired.

| Check | Result | Evidence |
|---|---|---|
| (n/a) | PASS | No audit triggers per SYSTEM_PROMPT |

## Acceptance Criteria Evidence

- [x] Workflow pins and merge-gate wiring match SoD follow-up issue — evidence: this PR diff and green Quality Gates.

## Test Plan Evidence

- [x] CI-only change; validated by repository Quality Gates workflow on this PR.

## Breaking Changes

None.

## Notes for Reviewer

Part of SoD remediation after unreviewed `rune-ci` `main` push (retro https://github.com/lpasquali/rune-ci/issues/26).
