### PR TITLE
chore(ci): pin lpasquali/rune-ci reusable workflows to 9f939b2

### DIFF
--- a/.github/workflows/bundle-ci.yml
+++ b/.github/workflows/bundle-ci.yml
@@ -313,6 +313,6 @@ jobs:
     name: "Merge Gate"
     if: always()
     needs: [validate-scripts, unit-tests, build-bundle, checksum-verify]
-    uses: lpasquali/rune-ci/.github/workflows/merge-gate-from-needs.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b
+    uses: lpasquali/rune-ci/.github/workflows/merge-gate-from-needs.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5
     with:
       needs-json: ${{ toJson(needs) }}

--- a/.github/workflows/project-backfill.yml
+++ b/.github/workflows/project-backfill.yml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   backfill:
-    uses: lpasquali/rune-ci/.github/workflows/project-backfill-logic.yml@main
+    uses: lpasquali/rune-ci/.github/workflows/project-backfill-logic.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   sync:
-    uses: lpasquali/rune-ci/.github/workflows/project-sync-logic.yml@b242495fb92b046879c9e0ecb8e88a0e89e0e7d5 # main
+    uses: lpasquali/rune-ci/.github/workflows/project-sync-logic.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # main
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -16,15 +16,15 @@ permissions:
 
 jobs:
   security:
-    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
+    uses: lpasquali/rune-ci/.github/workflows/security-scan.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # main
 
   shell:
-    uses: lpasquali/rune-ci/.github/workflows/shell-quality.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
+    uses: lpasquali/rune-ci/.github/workflows/shell-quality.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # main
     with:
       script-dirs: "scripts"
 
   validate:
-    uses: lpasquali/rune-ci/.github/workflows/generic-validate.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
+    uses: lpasquali/rune-ci/.github/workflows/generic-validate.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # main
     with:
       validate-yaml: "scripts/validate_yaml.py"
       validate-vex: "scripts/validate_vex.py"
@@ -32,6 +32,6 @@ jobs:
   compliance:
     needs: [security, shell, validate]
     if: always()
-    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@40149ab6e8d7305f01d31d3e53caa4da1361177b # main
+    uses: lpasquali/rune-ci/.github/workflows/pr-compliance.yml@9f939b2c28317b6f55c1913c6a6485bd91e1bda5 # main
     with:
       needs-json: ${{ toJson(needs) }}


### PR DESCRIPTION
## Summary

Pin every `lpasquali/rune-ci/.github/workflows/...` `workflow_call` to **`9f939b2c28317b6f55c1913c6a6485bd91e1bda5`** (current `rune-ci` `main`).

## Changes

- Replace prior SHAs: `40149ab…`, `b242495…`, `95f0b3…`, `ac0bd4…` (charts helm-release) where present.
- Replace `@main` branch pins on reusable workflow `uses:` with the same full SHA.

## Definition of Done

- [x] **Level 1**

## Acceptance Criteria Evidence

- All `uses: lpasquali/rune-ci/.github/workflows/…@` references in this repo use the new SHA; no `@main` for those paths.

## Audit Checks

No triggers fired.

## Breaking Changes

None.

Made with [Cursor](https://cursor.com)