### PR TITLE
feat(bundle): swap nginx base for caddy in INFRA_IMAGES (ADR 0008)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,7 +124,7 @@ rune-bundle-<tag>/
     rune-docs/
     rune-audit/
     zot-linux-amd64/
-    nginx/
+    caddy/
     ollama/              # (if --include-ollama)
     seaweedfs/           # (if --include-seaweedfs)
   charts/                # Packaged Helm charts (.tgz)

--- a/docs/crossplane.md
+++ b/docs/crossplane.md
@@ -62,7 +62,7 @@ This is the **same as Phase 1a** of the implementation and requires no external 
 
 This bundles:
 - RUNE suite images (rune, rune-operator, rune-ui, rune-audit, rune-docs)
-- Infrastructure images (nginx, Zot registry)
+- Infrastructure images (Caddy, Zot registry)
 - Optional: PostgreSQL image (for CNPG in-cluster)
 - **Crossplane v2.2.0** core image
 - **Crossplane functions**: patch-and-transform, go-templating, auto-ready

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -54,7 +54,7 @@ Bundle flags:
 | `--sign` | Sign images with cosign (requires `COSIGN_KEY` env or `--cosign-key`) |
 | `--dry-run` | List bundle contents without pulling anything |
 
-**Default bundle contents**: RUNE suite (rune, rune-operator, rune-ui) + infrastructure (nginx, Zot registry).
+**Default bundle contents**: RUNE suite (rune, rune-operator, rune-ui) + infrastructure (Caddy, Zot registry). Caddy is the base image used by `rune-docs` (per ADR 0008 in rune-docs); Zot is the in-cluster OCI registry.
 
 **Optional images** (dev/lab): PostgreSQL (via `--include-postgres`), Ollama, SeaweedFS. When included, `build-bundle.sh` resolves the image to an OCI digest via `crane`, pulls that pinned reference, and writes `images/<service>/bundle-meta.json` with source tag, digest, license, and provenance. The same fields are merged into `manifest.json`.
 

--- a/scripts/build-bundle.sh
+++ b/scripts/build-bundle.sh
@@ -43,7 +43,7 @@ readonly -a RUNE_IMAGES=(
 
 # Infrastructure images
 readonly -a INFRA_IMAGES=(
-    "docker.io/library/nginx:1.27.4-alpine"
+    "docker.io/library/caddy:2-alpine"
     "ghcr.io/project-zot/zot-linux-amd64:v2.1.2"
 )
 


### PR DESCRIPTION
## Summary

Carry the `rune-docs` base image change (nginx → Caddy; ADR 0008; merged in rune-docs#301) into the airgapped bundle so `rune-docs` is reproducibly buildable offline. Four file edits; no scripting logic changes.

Closes #86
Epic: #295 (rune-docs)

## DoD Level

- [x] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure**
- [ ] **Level 3 — Documentation**

## Level 1 Checklist

- [x] Tested in **docker-compose mode** — n/a (rune-airgapped is a build-time OCI bundle producer, not a running service). Build-bundle unit tests cover the relevant logic.
- [x] Tested in **kind (Kubernetes) mode** — n/a (bundle producer; deployment tests live in consumer repos / bootstrap scripts).
- [x] Tested in **standalone CLI mode** — `./scripts/build-bundle.sh --dry-run --tag test --output /tmp/test.tar.gz` runs and now lists `docker.io/library/caddy:2-alpine` under `=== Container Images ===`.
- [x] **Breaking change audit** — the bundle's infrastructure slot now carries Caddy instead of nginx; consumers of the bundle that previously used the nginx image directly (none known) would need to switch. `rune-docs` is the only documented consumer and already migrated. No persistence/API contract changes.
- [x] **Dependency CVE audit** — image is pulled/pinned by `build-bundle.sh` via `crane` at build time; the bundle's SBOM/CVE-policy job (RuneGate/Security/SBOM-and-CVE-Policy) will scan the rebuilt bundle on merge. `caddy:2-alpine` is a memory-safe Go binary on Alpine; three libxml2 VEX entries in rune-docs were deleted in rune-docs#301 because libxml2 is not present in the caddy image.

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| `cyber check:dep caddy` | PASS | Upstream decision in ADR 0008 (rune-docs#296); image is the official Docker Hub `library/caddy:2-alpine`. |
| `cyber check:supply-chain` | PASS | Bundle build path unchanged (`crane` pin + cosign). SBOM regenerated on next build. No new tool. |
| `legal check:dep caddy` | PASS | Apache-2.0; same family as the rest of RUNE. |

## Acceptance Criteria Evidence

- [x] Bundle dry-run contains `docker.io/library/caddy:2-alpine` and no `nginx:*` reference:
  ```
  === Container Images ===
    ...
    - docker.io/library/caddy:2-alpine
    - ghcr.io/project-zot/zot-linux-amd64:v2.1.2
  ```
- [x] `manifest.json` will list `caddy:2-alpine` (not nginx) on the next full build — generated at build time from `INFRA_IMAGES`; dry-run confirms the source list is correct.
- [x] `SHA256SUMS` regeneration unaffected — the digest/sign path is generic.
- [x] `docs/architecture.md` bundle tree renamed `images/nginx/` → `images/caddy/`.
- [x] `docs/deployment-guide.md` and `docs/crossplane.md` prose updated; ADR 0008 referenced.
- [x] `bash tests/test_build_bundle.sh` → **21 passed, 0 failed**.

## Test Plan Evidence

```
$ grep -rn 'nginx' scripts/ docs/
(no matches)

$ ./scripts/build-bundle.sh --dry-run --tag test --output /tmp/test.tar.gz
...
  - docker.io/library/caddy:2-alpine
...

$ bash tests/test_build_bundle.sh
...
=== Results: 21 passed, 0 failed ===
```

## Breaking Changes

None externally visible. Bundle consumers interact with RUNE images and charts; the infrastructure slot's contents are an implementation detail already identified by `manifest.json`.

## Notes for Reviewer

- This closes the rune-docs/rune-airgapped pair of the nginx-removal work. Next child is rune-charts#99 (optional Gateway API template, non-blocking) and rune-ci#41 (regression lint), then epic #295 closure + `CURRENT_STATE.md` persistence.
- No existing consumer of `INFRA_IMAGES` references `nginx` by name; the `rune-docs` Dockerfile pulls its base image by name directly and is independent of the bundle.

Made with [Cursor](https://cursor.com)