### PR TITLE
docs(readme): hyperlink PostgreSQL, CNPG, IEC 62443-4-1, and SLSA to official docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Airgapped deployment bundler for the RUNE platform.
 
-The default OCI bundle contains **RUNE suite images only** (rune, rune-operator, rune-ui, and supporting infrastructure). For **production**, provision PostgreSQL externally (CNPG, managed database) and configure via `RUNE_DB_URL` Secret. See [docs/deployment-guide.md](docs/deployment-guide.md) and [prerequisites matrix](docs/prerequisites.md).
+The default OCI bundle contains **RUNE suite images only** (rune, rune-operator, rune-ui, and supporting infrastructure). For **production**, provision [PostgreSQL](https://www.postgresql.org/docs/) externally ([CloudNativePG](https://cloudnative-pg.io/), managed database) and configure via `RUNE_DB_URL` Secret. See [docs/deployment-guide.md](docs/deployment-guide.md) and [prerequisites matrix](docs/prerequisites.md).
 
 For **development/lab** environments that need in-cluster PostgreSQL, build the bundle with `--include-postgres` flag. See [docs/deployment-guide.md#postgresql-optional](docs/deployment-guide.md#9-postgresql-optional) for details.
 
@@ -10,8 +10,8 @@ For **development/lab** environments that need in-cluster PostgreSQL, build the 
 All documentation is consolidated in the **[RUNE Documentation Site](https://lpasquali.github.io/rune-docs/)**.
 
 ## 🛡️ Compliance
-- **ML4**: This repository is designed to align with **IEC 62443-4-1 ML4** secure development requirements in preparation for future certification.
-- **SLSA**: Build provenance is designed to follow **SLSA Level 3** guidelines.
+- **ML4**: This repository is designed to align with **[IEC 62443-4-1](https://webstore.iec.ch/publication/33615) ML4** secure development requirements in preparation for future certification. ([ISA overview](https://www.isa.org/standards-and-publications/isa-standards/isa-iec-62443-series-of-standards))
+- **SLSA**: Build provenance is designed to follow **[SLSA Level 3](https://slsa.dev/spec/v1.0/)** guidelines.
 
 ## 📜 License
 Apache License 2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Hyperlinks **PostgreSQL**, **CloudNativePG**, **IEC 62443-4-1**, and **SLSA Level 3** in the README to their official docs/spec URLs. URLs from the rune-docs External Links Catalog.

Closes #90
Epic: —

## DoD Level

- [ ] **Level 1 — Full Validation** (runtime, API, Helm, Dockerfile)
- [ ] **Level 2 — Test Infrastructure** (test config, CI, coverage, linter)
- [x] **Level 3 — Documentation** (Markdown, MkDocs, diagrams)

## Level 3 Checklist

- [x] Manual diff review
- [x] Links resolve (HTTP 200/301): postgresql.org/docs, cloudnative-pg.io, webstore.iec.ch, isa.org, slsa.dev

## Audit Checks

No triggers fired.

## Acceptance Criteria Evidence

- [x] PostgreSQL → postgresql.org/docs — `README.md` diff
- [x] CNPG → cloudnative-pg.io — `README.md` diff
- [x] IEC 62443-4-1 → IEC Webstore + ISA overview — `README.md` diff
- [x] SLSA Level 3 → slsa.dev/spec/v1.0 — `README.md` diff

## Test Plan Evidence

- [x] Diff review: 1 file, 4 lines modified
- [x] All target URLs return 2xx/3xx

## Breaking Changes

None.

## Notes for Reviewer

Cross-repo sweep companion to rune-docs PR #307, rune#268, rune-operator#116, rune-ui#140, rune-charts#104.