### PR TITLE
feat(crossplane): helmfile release + airgapped values + tests (Phase 2)

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -16,6 +16,20 @@ environments:
       - values/production.yaml
 
 releases:
+  # Optional: Crossplane v2 for declarative infrastructure provisioning
+  # of external PostgreSQL / object-storage, via the XRDs + Compositions
+  # shipped in rune-charts/crossplane. Opt-in per environment via
+  # `crossplane.enabled: true` (default: false).
+  - name: crossplane
+    namespace: crossplane-system
+    chart: rune-local/crossplane
+    version: "{{ .Values.crossplaneVersion }}"
+    condition: crossplane.enabled
+    values:
+      - values/crossplane.yaml
+    labels:
+      tier: infrastructure
+
   - name: rune-operator
     namespace: rune-system
     chart: rune-local/rune-operator

--- a/tests/test_build_bundle.sh
+++ b/tests/test_build_bundle.sh
@@ -153,6 +153,48 @@ test_dry_run_with_ollama() {
     assert_contains "dry run with ollama shows ollama image" "ollama/ollama" "${output}"
 }
 
+test_dry_run_with_crossplane() {
+    echo "--- test_dry_run_with_crossplane ---"
+    local output
+    output="$(bash "${SCRIPT_UNDER_TEST}" \
+        --tag v0.0.0a2 \
+        --output /tmp/test-bundle.tar.gz \
+        --include-crossplane \
+        --dry-run 2>&1)" || true
+
+    assert_contains \
+        "dry run with crossplane shows crossplane core image" \
+        "ghcr.io/crossplane/crossplane:v2.2.0" "${output}"
+    assert_contains \
+        "dry run with crossplane shows provider-kubernetes" \
+        "provider-kubernetes" "${output}"
+    assert_contains \
+        "dry run with crossplane shows function-patch-and-transform" \
+        "function-patch-and-transform" "${output}"
+    assert_contains \
+        "dry run with crossplane shows function-go-templating" \
+        "function-go-templating" "${output}"
+}
+
+test_dry_run_without_crossplane_default() {
+    echo "--- test_dry_run_without_crossplane_default ---"
+    local output
+    output="$(bash "${SCRIPT_UNDER_TEST}" \
+        --tag v0.0.0a2 \
+        --output /tmp/test-bundle.tar.gz \
+        --dry-run 2>&1)" || true
+
+    if [[ "${output}" == *"crossplane"* ]]; then
+        echo "  FAIL: default bundle should NOT include crossplane images"
+        echo "    actual (crossplane lines):"
+        echo "${output}" | grep -i crossplane | sed 's/^/      /'
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    else
+        echo "  PASS: default bundle does not include crossplane images"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    fi
+}
+
 test_dry_run_with_sign() {
     echo "--- test_dry_run_with_sign ---"
     local output
@@ -204,6 +246,8 @@ test_unknown_option
 test_dry_run_mode
 test_dry_run_with_postgres
 test_dry_run_with_ollama
+test_dry_run_with_crossplane
+test_dry_run_without_crossplane_default
 test_dry_run_with_sign
 test_dry_run_architectures
 test_dry_run_no_changes

--- a/values/crossplane.yaml
+++ b/values/crossplane.yaml
@@ -1,0 +1,39 @@
+# Crossplane Helm values for air-gapped RUNE.
+#
+# Point Crossplane at the internal OCI registry (Zot) so provider /
+# function packages can be installed offline. See docs/crossplane.md
+# for when to enable Crossplane in air-gapped environments.
+#
+# These values mirror the upstream `ghcr.io/crossplane/crossplane`
+# Helm chart's `image` block; we only override the image location so
+# the Crossplane deployment pulls from the bundle-shipped image in
+# the local registry rather than from the public internet.
+---
+image:
+  repository: rune-registry.rune-registry.svc:5000/crossplane/crossplane
+  # Tag defaults to .Chart.AppVersion; when that is unacceptable
+  # (e.g. the bundle provides a different tag than the chart's
+  # AppVersion), override it explicitly here.
+  pullPolicy: IfNotPresent
+
+# Keep Crossplane's own metrics endpoint but do not install the
+# upstream ServiceMonitor — the cluster may not have Prometheus
+# Operator available in air-gapped mode. Operators can switch this
+# on after the fact.
+metrics:
+  enabled: true
+serviceMonitor:
+  enabled: false
+
+# Crossplane installs providers / functions as Package CRs post-install
+# (not via the Helm chart). Those manifests are expected to be applied
+# by the operator after `helmfile apply`; they reference packages in
+# xpkg.upbound.io/* that the bundle mirrors into the local registry.
+#
+# Example, operator-applied (NOT templated by this chart):
+#
+#   apiVersion: pkg.crossplane.io/v1
+#   kind: Provider
+#   metadata: { name: provider-kubernetes }
+#   spec:
+#     package: rune-registry.rune-registry.svc:5000/crossplane-contrib/provider-kubernetes:v1.2.1

--- a/values/defaults.yaml
+++ b/values/defaults.yaml
@@ -3,6 +3,15 @@
 ---
 runeVersion: "0.0.0a2"
 
+# Crossplane — optional infrastructure provisioning layer.
+# When crossplane.enabled is true, helmfile will install the Crossplane
+# core chart + providers/functions from the local OCI registry. See
+# docs/crossplane.md for when to enable it (partially-connected airgap
+# only — fully disconnected should use the CNPG on-prem path).
+crossplaneVersion: "2.2.0"
+crossplane:
+  enabled: false
+
 global:
   imageRegistry: "rune-registry.rune-registry.svc:5000"
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

Close the remaining gap in #84. The \`--include-crossplane\` flag and bundle images landed earlier in \`build-bundle.sh\`; what was missing was the Helmfile release, the airgapped values overrides, and the test cases. This PR adds them.

Closes #84
Epic: rune-docs#266

## DoD Level

- [ ] Level 1 / [x] **Level 2 — Test Infrastructure** / [ ] Level 3

## Level 2 Checklist

- [x] Full test suite passes — \`bash tests/test_build_bundle.sh\` → **26 passed, 0 failed** (was 21; +5 new assertions across 2 new tests).
- [x] Coverage not degraded — test-only additions; no runtime behavior change when the flag is absent.
- [x] No unintended CI side effects.

## Audit Checks

| Check | Result | Evidence |
|---|---|---|
| \`legal check:dep crossplane\` | PASS | Apache-2.0 (Crossplane core + functions + provider-kubernetes), per rune-docs ADR 0007 supply-chain table. |
| \`cyber check:supply-chain\` | PASS | All images resolve from \`rune-registry.rune-registry.svc:5000/*\` (internal Zot). Bundle already mirrors them under \`--include-crossplane\`. |

## Acceptance Criteria Evidence

- [x] \`bash tests/test_build_bundle.sh\` passes including new Crossplane tests:
  \`\`\`
  --- test_dry_run_with_crossplane ---
    PASS: dry run with crossplane shows crossplane core image
    PASS: dry run with crossplane shows provider-kubernetes
    PASS: dry run with crossplane shows function-patch-and-transform
    PASS: dry run with crossplane shows function-go-templating
  --- test_dry_run_without_crossplane_default ---
    PASS: default bundle does not include crossplane images
  === Results: 26 passed, 0 failed ===
  \`\`\`
- [x] \`--include-crossplane\` dry-run output lists all 4 Crossplane images (verified by the 4 assertions above).
- [x] Default bundle (no flag) does NOT include Crossplane images (test \`test_dry_run_without_crossplane_default\`).
- [x] Helmfile release is conditional on \`crossplane.enabled: true\`:
  \`\`\`yaml
  - name: crossplane
    namespace: crossplane-system
    chart: rune-local/crossplane
    version: \"{{ .Values.crossplaneVersion }}\"
    condition: crossplane.enabled
    values:
      - values/crossplane.yaml
    labels:
      tier: infrastructure
  \`\`\`
- [x] YAML validity: \`helmfile.yaml\`, \`values/crossplane.yaml\`, \`values/defaults.yaml\` all parse cleanly with PyYAML.
- [x] \`shellcheck\` clean on modified scripts — runs in CI (\`shell / RuneGate/Lint/ShellCheck\`).

## Test Plan Evidence

\`\`\`
$ bash tests/test_build_bundle.sh
=== Results: 26 passed, 0 failed ===

$ python3 -c \"import yaml; yaml.safe_load_all(open('helmfile.yaml'))\"   # exit 0
$ python3 -c \"import yaml; yaml.safe_load(open('values/crossplane.yaml'))\"   # exit 0
$ python3 -c \"import yaml; yaml.safe_load(open('values/defaults.yaml'))\"   # exit 0
\`\`\`

## Breaking Changes

None. \`crossplane.enabled\` defaults to \`false\`, so the Helmfile apply path is unchanged for existing airgapped deployments.

## Notes for Reviewer

- Crossplane package CRs (Provider / Function) are **intentionally not templated by this chart**. Crossplane installs them as Package CRs post-Helm-install; the operator applies them referencing image paths under \`rune-registry.rune-registry.svc:5000/*\`. A commented example is in \`values/crossplane.yaml\`.
- Image tag is driven by \`crossplaneVersion\` in \`values/defaults.yaml\` (currently \`2.2.0\`) — matches the tag pulled by \`build-bundle.sh\` and the Chart.AppVersion expectation.
- With this PR, epic rune-docs#266 Phase 2 is complete. Only Phase 3 (\`RuneBenchmark.spec.infrastructureRef\`, rune-operator#107) remains, and it is explicitly deferred.

Made with [Cursor](https://cursor.com)